### PR TITLE
enhance(dataset): use Dataset as type hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,22 @@ metadata = {
 # upload the local file to Walden's cache
 dataset = Dataset.copy_and_create(local_file, metadata)
 
+# upload the file from URL to Walden's cache, make sure
+# to set `source_data_url`
+# dataset = Dataset.download_and_create(metadata)
+
 # save the JSON metadata locally in the right place
 dataset.save()
 
 # upload the file to S3 as either public or private
 dataset.upload(public=True)
+```
+
+or simply
+
+```python
+from owid.walden import add_to_catalog
+add_to_catalog(metadata, local_file, upload=True)
 ```
 
 You have to commit and push the JSON file in the `index/` folder to make it available to others:
@@ -90,6 +101,8 @@ git add index/
 git commit -m 'Add my shiny new dataset'
 git push
 ```
+
+It is a good practice to add the script you used for uploading the file to walden to [walden/ingests](https://github.com/owid/walden/tree/master/ingests) folder.
 
 ### Manually
 
@@ -103,7 +116,19 @@ You can also do all of this manually:
 
 ## Using the catalog
 
-A basic Python API is available, suggestions for improvement are most welcome:
+A basic Python API is available, suggestions for improvement are most welcome.
+
+The most basic method to get the data from catalog is:
+
+```python
+from owid.walden import Catalog
+
+dataset = Catalog().find_one(namespace="wb", version="2021-07-01", short_name="wb_income")
+local_path = dataset.ensure_downloaded()
+df = pd.read_csv(local_path)
+```
+
+You can also iterate over all datasets in the catalog:
 
 ```python
 from owid.walden import Catalog

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ from owid.walden import Catalog
 
 dataset = Catalog().find_one(namespace="wb", version="2021-07-01", short_name="wb_income")
 local_path = dataset.ensure_downloaded()
-df = pd.read_csv(local_path)
+df = pd.read_csv(local_path)  # assuming the file is a csv
 ```
 
 You can also iterate over all datasets in the catalog:

--- a/ingests/wb_income_groups.py
+++ b/ingests/wb_income_groups.py
@@ -7,13 +7,13 @@ poetry run python -m ingests.wb_income_groups
 ```
 """
 import tempfile
-from datetime import datetime
+import datetime as dt
 import unicodedata
 
 import pandas as pd
 import click
 from owid.walden import files, add_to_catalog
-
+from owid.walden.catalog import Dataset
 
 SOURCE_DATA_URL = "http://databank.worldbank.org/data/download/site-content/CLASS.xlsx"
 SHORT_NAME = "wb_income"
@@ -25,28 +25,27 @@ def load_metadata_description():
     return unicodedata.normalize("NFKD", s)
 
 
-def create_metadata_dict():
-    return {
-        "namespace": "wb",
-        "short_name": SHORT_NAME,
-        "name": "World Bank list of economies - World Bank (July 2021)",
-        "source_name": "World Bank",
-        "url": "https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups",
-        "source_data_url": SOURCE_DATA_URL,
-        "description": load_metadata_description(),
-        "date_accessed": datetime.now().date().strftime("%Y-%m-%d"),
-        "publication_year": 2021,
-        "publication_date": "2021-07-01",
-        "owid_data_url": f"https://walden.nyc3.digitaloceanspaces.com/wb/2021-07-01/{SHORT_NAME}.xlsx",
-        "file_extension": "xlsx",
-        "license_name": "CC BY 4.0",
-        "license_url": "https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets",
-    }
+def create_metadata():
+    return Dataset(
+        namespace="wb",
+        short_name=SHORT_NAME,
+        name="World Bank list of economies - World Bank (July 2021)",
+        source_name="World Bank",
+        url="https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups",
+        source_data_url=SOURCE_DATA_URL,
+        description=load_metadata_description(),
+        date_accessed=dt.datetime.now().date().strftime("%Y-%m-%d"),
+        publication_year=2021,
+        publication_date=dt.date(2021, 7, 1),
+        file_extension="xlsx",
+        license_name="CC BY 4.0",
+        license_url="https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets",
+    )
 
 
-def check_date(metadata):
+def check_date(metadata: Dataset):
     s = "Income classifications set on 1 July 2021 remain in effect until 1 July 2022"
-    if s not in metadata["description"]:
+    if s not in metadata.description:
         raise ValueError(
             "Source data is no longer from 2021. Or something has changed in Notes sheet!"
         )
@@ -54,11 +53,12 @@ def check_date(metadata):
 
 @click.command()
 def main():
-    metadata = create_metadata_dict()
+    metadata = create_metadata()
     check_date(metadata)
     with tempfile.NamedTemporaryFile() as f:
         # fetch the file locally
-        files.download(metadata["source_data_url"], f.name)
+        assert metadata.source_data_url is not None
+        files.download(metadata.source_data_url, f.name)
         # add it to walden, both locally, and to our remote file cache
         add_to_catalog(metadata, f.name, upload=True)
 

--- a/owid/walden/ingest.py
+++ b/owid/walden/ingest.py
@@ -1,11 +1,12 @@
 """Tools to inges to Walden and Catalog."""
 
+from typing import Union
 
 from .catalog import Dataset
 from .ui import log
 
 
-def add_to_catalog(metadata: dict, filename: str, upload: bool = False):
+def add_to_catalog(metadata: Union[dict, Dataset], filename: str, upload: bool = False):
     """Add metadata to catalog.
 
     Additionally, it computes the md5 hash of the file, which is added to the metadata file.


### PR DESCRIPTION
Couple of usability improvements after our pairing session with @pabloarosado 

1. Improved documentation
2. Use `Dataset` for type hints instead of creating metadata as a dictionary
3. Clarify some metadata fields

I was thinking about creating its own `DatasetMeta` class and inheriting from it in `Dataset`, but I'm not sure whether that would make it more clear or not...

Lastly, is there a reason why don't we implicitly use extension from file name / url?