### PR TITLE
fix(files): do not stream to NamedTempFile because of weird issues

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -48,7 +48,9 @@ def test_download_with_md5():
 
 
 def test_download_with_wrong_md5_raises():
-    with requests_mock.Mocker() as mocker, tempfile.NamedTemporaryFile() as destination:
+    with requests_mock.Mocker() as mocker, tempfile.NamedTemporaryFile(
+        delete=False
+    ) as destination:
         data_url = "https://very/important/data.csv"
         mocker.get(data_url, content=encoded)
         with pytest.raises(files.ChecksumDoesNotMatch):


### PR DESCRIPTION
Solves https://github.com/owid/etl/issues/86. Version with `NamedTemporaryFile` didn't calculate md5 checksums correctly on @lucasrodes OS for some reason.