### PR TITLE
Allow custom version in datasets

### DIFF
--- a/owid/walden/catalog.py
+++ b/owid/walden/catalog.py
@@ -108,7 +108,10 @@ class Dataset:
 
     @classmethod
     def copy_and_create(
-        cls, filename: str, metadata: Union[dict, "Dataset"], version: Optional[str] = None
+        cls,
+        filename: str,
+        metadata: Union[dict, "Dataset"],
+        version: Optional[str] = None,
     ) -> "Dataset":
         """
         Create a new dataset if you already have the file locally.

--- a/owid/walden/ingest.py
+++ b/owid/walden/ingest.py
@@ -6,7 +6,12 @@ from .catalog import Dataset
 from .ui import log
 
 
-def add_to_catalog(metadata: Union[dict, Dataset], filename: str, upload: bool = False, version: Optional[str] = None):
+def add_to_catalog(
+    metadata: Union[dict, Dataset],
+    filename: str,
+    upload: bool = False,
+    version: Optional[str] = None,
+):
     """Add metadata to catalog.
 
     Additionally, it computes the md5 hash of the file, which is added to the metadata file.

--- a/owid/walden/ingest.py
+++ b/owid/walden/ingest.py
@@ -1,12 +1,12 @@
 """Tools to ingest to Walden and Catalog."""
 
-from typing import Union
+from typing import Optional, Union
 
 from .catalog import Dataset
 from .ui import log
 
 
-def add_to_catalog(metadata: Union[dict, Dataset], filename: str, upload: bool = False):
+def add_to_catalog(metadata: Union[dict, Dataset], filename: str, upload: bool = False, version: Optional[str] = None):
     """Add metadata to catalog.
 
     Additionally, it computes the md5 hash of the file, which is added to the metadata file.
@@ -15,10 +15,12 @@ def add_to_catalog(metadata: Union[dict, Dataset], filename: str, upload: bool =
 
     Args:
         metadata (dict): Dictionary with metadata.
-        local_path (str): Path to local data file. Used to compute the md5 hash.
+        filename (str): Path to local data file. Used to compute the md5 hash.
+        upload (bool): True to upload to DigitalOcean.
+        version (str): Version to assign to dataset (if not given, it will be set based on dataset metadata).
     """
     # checksum happens in here, copy to cache happens here
-    dataset = Dataset.copy_and_create(filename, metadata)
+    dataset = Dataset.copy_and_create(filename, metadata, version)
 
     if upload:
         # add it to our DigitalOcean Space and set `owid_cache_url`


### PR DESCRIPTION
This PR would be an alternative to [this other PR](https://github.com/owid/walden/pull/28).
* Add `modification_date` as a new field in metadata. This could be removed (I think it is useful, but not absolutely necessary).
* Allow `version` to be set by the user. The logic would be that, if `version` is not set by the user, then check for `modification_date`, otherwise `publication_date`, and otherwise `publication_year` in the metadata.
