### PR TITLE
Sort faostat by date accessed

### DIFF
--- a/owid/walden/index/faostat/2022-04-25/faostat_FBS.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_FBS.json
@@ -1,0 +1,19 @@
+{
+  "namespace": "faostat",
+  "short_name": "faostat_FBS",
+  "name": "Food Balances: Food Balances (2010-) - FAO (2022)",
+  "description": "Food Balance Sheet presents a comprehensive picture of the pattern of a country's food supply during a specified reference period. The food balance sheet shows for each food item - i.e. each primary commodity and a number of processed commodities potentially available for human consumption - the sources of supply and its utilization. The total quantity of foodstuffs produced in a country added to the total quantity imported and adjusted to any change in stocks that may have occurred since the beginning of the reference period gives the supply available during that period. On the utilization side a distinction is made between the quantities exported, fed to livestock, used for seed, put to manufacture for food use and non-food uses, losses during storage and transportation, and food supplies available for human consumption. The per caput supply of each such food item available for human consumption is then obtained by dividing the respective quantity by the related data on the population actually partaking of it. Data on per caput food supplies are expressed in terms of quantity and - by applying appropriate food composition factors for all primary and processed products - also in terms of caloric value and protein and fat content.",
+  "source_name": "Food and Agriculture Organization of the United Nations",
+  "url": "http://www.fao.org/faostat/en/#data",
+  "file_extension": "zip",
+  "date_accessed": "2022-04-25",
+  "source_data_url": "https://fenixservices.fao.org/faostat/static/bulkdownloads/FoodBalanceSheets_E_All_Data_(Normalized).zip",
+  "license_url": "http://www.fao.org/contact-us/terms/db-terms-of-use/en",
+  "license_name": "CC BY-NC-SA 3.0 IGO",
+  "is_public": true,
+  "publication_year": 2022,
+  "publication_date": "2022-02-14",
+  "modification_date": "2022-02-14",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_FBS.zip",
+  "md5": "b67bee617e0fc2fd2d2e00c641915948"
+}

--- a/owid/walden/index/faostat/2022-04-25/faostat_FBS.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_FBS.json
@@ -13,7 +13,6 @@
   "is_public": true,
   "publication_year": 2022,
   "publication_date": "2022-02-14",
-  "modification_date": "2022-02-14",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_FBS.zip",
   "md5": "b67bee617e0fc2fd2d2e00c641915948"
 }

--- a/owid/walden/index/faostat/2022-04-25/faostat_FBSH.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_FBSH.json
@@ -13,7 +13,6 @@
   "is_public": true,
   "publication_year": 2021,
   "publication_date": "2021-12-03",
-  "modification_date": "2021-12-03",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_FBSH.zip",
   "md5": "f3a247f9b9c130e92ecfc2072fbbcdd6"
 }

--- a/owid/walden/index/faostat/2022-04-25/faostat_FBSH.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_FBSH.json
@@ -1,0 +1,19 @@
+{
+  "namespace": "faostat",
+  "short_name": "faostat_FBSH",
+  "name": "Food Balances: Food Balances (-2013, old methodology and population) - FAO (2021)",
+  "description": "Food Balance Sheet presents a comprehensive picture of the pattern of a country's food supply during a specified reference period. The food balance sheet shows for each food item - i.e. each primary commodity and a number of processed commodities potentially available for human consumption - the sources of supply and its utilization. The total quantity of foodstuffs produced in a country added to the total quantity imported and adjusted to any change in stocks that may have occurred since the beginning of the reference period gives the supply available during that period. On the utilization side a distinction is made between the quantities exported, fed to livestock, used for seed, put to manufacture for food use and non-food uses, losses during storage and transportation, and food supplies available for human consumption. The per caput supply of each such food item available for human consumption is then obtained by dividing the respective quantity by the related data on the population actually partaking of it. Data on per caput food supplies are expressed in terms of quantity and - by applying appropriate food composition factors for all primary and processed products - also in terms of caloric value and protein and fat content.",
+  "source_name": "Food and Agriculture Organization of the United Nations",
+  "url": "http://www.fao.org/faostat/en/#data",
+  "file_extension": "zip",
+  "date_accessed": "2022-04-25",
+  "source_data_url": "https://fenixservices.fao.org/faostat/static/bulkdownloads/FoodBalanceSheetsHistoric_E_All_Data_(Normalized).zip",
+  "license_url": "http://www.fao.org/contact-us/terms/db-terms-of-use/en",
+  "license_name": "CC BY-NC-SA 3.0 IGO",
+  "is_public": true,
+  "publication_year": 2021,
+  "publication_date": "2021-12-03",
+  "modification_date": "2021-12-03",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_FBSH.zip",
+  "md5": "f3a247f9b9c130e92ecfc2072fbbcdd6"
+}

--- a/owid/walden/index/faostat/2022-04-25/faostat_FS.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_FS.json
@@ -13,7 +13,6 @@
   "is_public": true,
   "publication_year": 2021,
   "publication_date": "2021-08-18",
-  "modification_date": "2022-04-06",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_FS.zip",
   "md5": "93611821b002603fcc29a0b779ad1a38"
 }

--- a/owid/walden/index/faostat/2022-04-25/faostat_FS.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_FS.json
@@ -1,0 +1,19 @@
+{
+  "namespace": "faostat",
+  "short_name": "faostat_FS",
+  "name": "Food Security and Nutrition: Suite of Food Security Indicators - FAO (2021)",
+  "description": "Suite of Food Security Indicators presents the core set of food security indicators. Following the recommendation of experts gathered in the Committee on World Food Security (CFS) Round Table on hunger measurement, hosted at FAO headquarters in September 2011, an initial set of indicators aiming to capture various aspects of food insecurity is presented here. The choice of the indicators has been informed by expert judgment and the availability of data with sufficient coverage to enable comparisons across regions and over time. Many of these indicators are produced and published elsewhere by FAO and other international organizations. They are reported here in a single database with the aim of building a wide food security information system. More indicators will be added to this set as more data will become available. Indicators are classified along the four dimensions of food security -- availability, access, utilization and stability. For definitions of these indicators, see Definitions and standards below (under Item).",
+  "source_name": "Food and Agriculture Organization of the United Nations",
+  "url": "http://www.fao.org/faostat/en/#data",
+  "file_extension": "zip",
+  "date_accessed": "2022-04-25",
+  "source_data_url": "https://fenixservices.fao.org/faostat/static/bulkdownloads/Food_Security_Data_E_All_Data_(Normalized).zip",
+  "license_url": "http://www.fao.org/contact-us/terms/db-terms-of-use/en",
+  "license_name": "CC BY-NC-SA 3.0 IGO",
+  "is_public": true,
+  "publication_year": 2021,
+  "publication_date": "2021-08-18",
+  "modification_date": "2022-04-06",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_FS.zip",
+  "md5": "93611821b002603fcc29a0b779ad1a38"
+}

--- a/owid/walden/index/faostat/2022-04-25/faostat_QCL.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_QCL.json
@@ -13,7 +13,6 @@
   "is_public": true,
   "publication_year": 2022,
   "publication_date": "2022-02-16",
-  "modification_date": "2022-02-25",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_QCL.zip",
   "md5": "0f977108b3b3da80bde2958d292a9d61"
 }

--- a/owid/walden/index/faostat/2022-04-25/faostat_QCL.json
+++ b/owid/walden/index/faostat/2022-04-25/faostat_QCL.json
@@ -1,0 +1,19 @@
+{
+  "namespace": "faostat",
+  "short_name": "faostat_QCL",
+  "name": "Production: Crops and livestock products - FAO (2022)",
+  "description": "Crop statistics are recorded for 173 products, covering the following categories: Crops Primary, Fibre Crops Primary, Cereals, Coarse Grain, Citrus Fruit, Fruit, Jute Jute-like Fibres, Oilcakes Equivalent, Oil crops Primary, Pulses, Roots and Tubers, Treenuts and Vegetables and Melons. Data are expressed in terms of area harvested, production quantity and yield. The objective is to comprehensively cover production of all primary crops for all countries and regions in the world.Cereals: Area and production data on cereals relate to crops harvested for dry grain only. Cereal crops harvested for hay or harvested green for food, feed or silage or used for grazing are therefore excluded. Area data relate to harvested area. Some countries report sown or cultivated area only",
+  "source_name": "Food and Agriculture Organization of the United Nations",
+  "url": "http://www.fao.org/faostat/en/#data",
+  "file_extension": "zip",
+  "date_accessed": "2022-04-25",
+  "source_data_url": "https://fenixservices.fao.org/faostat/static/bulkdownloads/Production_Crops_Livestock_E_All_Data_(Normalized).zip",
+  "license_url": "http://www.fao.org/contact-us/terms/db-terms-of-use/en",
+  "license_name": "CC BY-NC-SA 3.0 IGO",
+  "is_public": true,
+  "publication_year": 2022,
+  "publication_date": "2022-02-16",
+  "modification_date": "2022-02-25",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-25/faostat_QCL.zip",
+  "md5": "0f977108b3b3da80bde2958d292a9d61"
+}

--- a/owid/walden/ingest.py
+++ b/owid/walden/ingest.py
@@ -1,10 +1,8 @@
 """Tools to ingest to Walden and Catalog."""
 
 from typing import Optional, Union
-from pathlib import Path
 
-from .catalog import Dataset, INDEX_DIR
-from .files import iter_docs
+from .catalog import Dataset
 from .ui import log
 
 
@@ -37,30 +35,3 @@ def add_to_catalog(
     dataset.save()
 
     log("ADDED TO CATALOG", f"{dataset.relative_base}.json")
-
-
-def is_metadata_in_index(namespace, partial_metadata):
-    """Read all metadata files in the walden index, under a certain namespace, and return True if partial_metadata is
-    contained in any of them, with identical values.
-
-    Args:
-        namespace (str): Namespace in walden index.
-        partial_metadata (dict): Fields in metadata to check for matches.
-    """
-    index_dir = Path(INDEX_DIR) / namespace
-    metadata_in_index = False
-    # If namespace is not found, there are obviously no matches.
-    if index_dir.is_dir():
-        for filename, index_file in iter_docs(index_dir):
-            # Iterate over all files in index and check if any of their metadata matches the fields in partial_metadata.
-            dataset_found = True
-            for metadata_field in partial_metadata:
-                dataset_found &= (
-                    index_file.get(metadata_field) == partial_metadata[metadata_field]
-                )
-
-            if dataset_found:
-                log("INFO", f"Metadata already exists in index file: {filename}")
-                metadata_in_index = True
-
-    return metadata_in_index

--- a/owid/walden/ingest.py
+++ b/owid/walden/ingest.py
@@ -1,8 +1,10 @@
 """Tools to ingest to Walden and Catalog."""
 
 from typing import Optional, Union
+from pathlib import Path
 
-from .catalog import Dataset
+from .catalog import Dataset, INDEX_DIR
+from .files import iter_docs
 from .ui import log
 
 
@@ -35,3 +37,30 @@ def add_to_catalog(
     dataset.save()
 
     log("ADDED TO CATALOG", f"{dataset.relative_base}.json")
+
+
+def is_metadata_in_index(namespace, partial_metadata):
+    """Read all metadata files in the walden index, under a certain namespace, and return True if partial_metadata is
+    contained in any of them, with identical values.
+
+    Args:
+        namespace (str): Namespace in walden index.
+        partial_metadata (dict): Fields in metadata to check for matches.
+    """
+    index_dir = Path(INDEX_DIR) / namespace
+    metadata_in_index = False
+    # If namespace is not found, there are obviously no matches.
+    if index_dir.is_dir():
+        for filename, index_file in iter_docs(index_dir):
+            # Iterate over all files in index and check if any of their metadata matches the fields in partial_metadata.
+            dataset_found = True
+            for metadata_field in partial_metadata:
+                dataset_found &= (
+                    index_file.get(metadata_field) == partial_metadata[metadata_field]
+                )
+
+            if dataset_found:
+                log("INFO", f"Metadata already exists in index file: {filename}")
+                metadata_in_index = True
+
+    return metadata_in_index


### PR DESCRIPTION
**UPDATE**: I would suggest to cancel this PR and instead continue on [this PR](https://github.com/owid/walden/pull/32).

This PR would be an alternative to [this other PR](https://github.com/owid/walden/pull/27/files).
~* Store downloaded FAOstat files in a folder based on `date_accessed` instead of `publication_date` or `modification_date`.~
~TODO: To avoid downloading many times the same files, we could first check if a certain dataset already exists in index with the same `publication_date` and `modification_date`. If so, skip.~
~* Avoid downloading a dataset if a file with the same `source_data_url`, `publication_date` and `modification_date` (if given) already exists in walden index.~
* Store downloaded FAOstat files in a folder based on `version` (which is set to `date_accessed`) instead of `publication_date`.
* Avoid downloading a dataset if a file with the same `source_data_url` already exists in walden index, with a `date_accessed` more recent than the latest modification date of the dataset.
