### PR TITLE
Add faostat dataset to index

### DIFF
--- a/ingests/faostat.py
+++ b/ingests/faostat.py
@@ -32,6 +32,8 @@ INCLUDED_DATASETS_CODES = [
     "fbsh",
     # Production: Crops and livestock products
     "qcl",
+    # Land, Inputs and Sustainability: Land Use
+    "rl",
 ]
 
 VERSION = str(dt.date.today())

--- a/owid/walden/index/faostat/2022-04-26/faostat_rl.json
+++ b/owid/walden/index/faostat/2022-04-26/faostat_rl.json
@@ -1,0 +1,19 @@
+{
+  "namespace": "faostat",
+  "short_name": "faostat_rl",
+  "name": "Land, Inputs and Sustainability: Land Use - FAO (2021)",
+  "description": "The FAOSTAT Land Use domain contains data on forty-four categories of land use, irrigation and agricultural practices, relevant to monitor agriculture, forestry and fisheries activities at national, regional and global level. Data are available by country and year, with global coverage and annual updates.",
+  "source_name": "Food and Agriculture Organization of the United Nations",
+  "url": "http://www.fao.org/faostat/en/#data",
+  "file_extension": "zip",
+  "date_accessed": "2022-04-26",
+  "source_data_url": "https://fenixservices.fao.org/faostat/static/bulkdownloads/Inputs_LandUse_E_All_Data_(Normalized).zip",
+  "license_url": "http://www.fao.org/contact-us/terms/db-terms-of-use/en",
+  "license_name": "CC BY-NC-SA 3.0 IGO",
+  "is_public": true,
+  "version": "2022-04-26",
+  "publication_year": 2021,
+  "publication_date": "2021-06-17",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-04-26/faostat_rl.zip",
+  "md5": "f674d66f36b564c17cc6f96203dceb0d"
+}


### PR DESCRIPTION
* Add "rl" dataset code to FAOstat ingest script.

This dataset code was not included in the list `INCLUDED_DATASETS_CODES`, and I suppose it should be included (since it is used later on in `etl` steps).
