### PR TITLE
fix(faostat): fix faostat metadata index file

### DIFF
--- a/owid/walden/index/faostat/2022-05-17/faostat_metadata.json
+++ b/owid/walden/index/faostat/2022-05-17/faostat_metadata.json
@@ -15,5 +15,5 @@
   "publication_year": 2022,
   "publication_date": "2022-05-17",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/faostat/2022-05-17/faostat_metadata.json",
-  "md5": "4a12ef2b577ab4cca9e64bc13a10824c"
+  "md5": "492547561a45f3698b4aaffc804ab01a"
 }


### PR DESCRIPTION
There was a problem with the faostat_metadata.json file ingested into walden. I have fixed that, and have updated the md5 in the index file.
