### PR TITLE
enhance(catalog): add method for deleting dataset from S3

### DIFF
--- a/owid/walden/catalog.py
+++ b/owid/walden/catalog.py
@@ -215,6 +215,13 @@ class Dataset:
 
         self.is_public = public
 
+    def delete_from_remote(self) -> None:
+        """
+        Delete the file from the remote cache on S3.
+        """
+        dest_path = f"https://{self.relative_base}.{self.file_extension}"
+        owid_cache.delete(dest_path)
+
     @property
     def local_path(self) -> str:
         return path.join(CACHE_DIR, f"{self.relative_base}.{self.file_extension}")

--- a/owid/walden/owid_cache.py
+++ b/owid/walden/owid_cache.py
@@ -46,6 +46,24 @@ def upload(filename: str, relative_path: str, public: bool = False) -> str:
     return f"{HTTPS_BASE}/{relative_path}"
 
 
+def delete(relative_path: str, quiet: bool = False):
+    """Delete object at given S3 URL."""
+    s3_url = f"{S3_BASE}/{relative_path}"
+
+    client = connect()
+
+    bucket, key = s3_bucket_key(s3_url)
+
+    try:
+        client.delete_object(Bucket=bucket, Key=key)
+    except ClientError as e:
+        logging.error(e)
+        raise DeleteError(e)
+
+    if not quiet:
+        log("DELETED", f"{s3_url}")
+
+
 def s3_bucket_key(url: str) -> Tuple[str, str]:
     """Get bucket and key from either s3:// URL or https:// URL."""
     parsed = urlparse(url)
@@ -110,4 +128,8 @@ aws_secret_access_key = ...
 
 
 class UploadError(Exception):
+    pass
+
+
+class DeleteError(Exception):
     pass


### PR DESCRIPTION
PR required for https://github.com/owid/etl/pull/219.

(We should consider moving the entire `owid-cache.py` to [datautils](https://github.com/owid/data-utils-py) as the code is being duplicated elsewhere as well. However, we're blocked by the fact that `data-utils-py` has `owid-catalog-py` as a dependency)