### PR TITLE
feature(catalog): add global catalog

### DIFF
--- a/owid/walden/__init__.py
+++ b/owid/walden/__init__.py
@@ -1,2 +1,15 @@
 from .catalog import Dataset, Catalog  # noqa
 from .ingest import add_to_catalog  # noqa
+
+
+_cache = {}
+
+
+def __getattr__(name: str) -> Catalog:
+    if name == "CATALOG":
+        # cached walden catalog instance to avoid repeated slow loading, call
+        # `refresh` to force reload
+        if "CATALOG" not in _cache:
+            _cache["CATALOG"] = Catalog()
+        return _cache["CATALOG"]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/owid/walden/catalog.py
+++ b/owid/walden/catalog.py
@@ -278,10 +278,14 @@ class Catalog:
 
     def find_latest(
         self,
-        namespace: Optional[str] = None,
-        short_name: Optional[str] = None,
+        namespace: str,
+        short_name: str,
     ) -> Dataset:
         matches = self.find(namespace=namespace, short_name=short_name)
+        if not matches:
+            raise ValueError(
+                f"Dataset {short_name} in namespace {namespace} not found in walden"
+            )
         _, dataset = max((d.version, d) for d in matches)
         return dataset
 


### PR DESCRIPTION
Now that we have more than a thousand datasets, instantiating Walden catalog can take a long time (>2s). This becomes a bottleneck for fast-track. Having global `owid.walden.CATALOG` is a convenient way how to avoid this (and we have something similar in `owid-catalog-py` for `RemoteCatalog`). We can refresh the catalog manually with

```
from owid.catalog import CATALOG as WALDEN_CATALOG
WALDEN_CATALOG.refresh()
```

manual refresh is only used in fast-track, cached version is fine everywhere else.