### PR TITLE
fix: UN WPP

### DIFF
--- a/ingests/un_wpp.py
+++ b/ingests/un_wpp.py
@@ -116,6 +116,7 @@ def prepare_data(directory):
     output_zip = "un_wpp"
     download_data(directory)
     unzip_data(directory)
+    clean_directory(directory)
     output_file = compress_directory(directory, output_zip)
     return output_file
 

--- a/owid/walden/index/un/2022-07-11/un_wpp.json
+++ b/owid/walden/index/un/2022-07-11/un_wpp.json
@@ -15,5 +15,5 @@
   "publication_year": 2022,
   "publication_date": "2022-07-11",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/un/2022-07-11/un_wpp.zip",
-  "md5": "4dd7c164bc77411ef264e4584ac324d1"
+  "md5": "91d516e4ba7dc26d7ff8ce94e4cd0159"
 }


### PR DESCRIPTION
Fix zip folder. In the prior version, the zip folder contained unnecessary and redundant files.