### PR TITLE
data(un_wpp): add constant fertility variant for population

### DIFF
--- a/ingests/un_wpp.py
+++ b/ingests/un_wpp.py
@@ -31,6 +31,7 @@ URLS = {
         "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2022_PopulationBySingleAgeSex_Medium_2022-2100.zip",
         "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2022_PopulationBySingleAgeSex_High_2022-2100.zip",
         "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2022_PopulationBySingleAgeSex_Low_2022-2100.zip",
+        "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/WPP2022_PopulationBySingleAgeSex_Constant%20fertility_2022-2100.zip",
     ],
     "deaths": [
         "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/EXCEL_FILES/4_Mortality/WPP2022_MORT_F01_1_DEATHS_SINGLE_AGE_BOTH_SEXES.xlsx",

--- a/owid/walden/index/un/2022-07-11/un_wpp.json
+++ b/owid/walden/index/un/2022-07-11/un_wpp.json
@@ -6,7 +6,7 @@
   "source_name": "United Nations, Department of Economic and Social Affairs, Population Division (2022)",
   "url": "https://population.un.org/wpp/Download/",
   "file_extension": "zip",
-  "date_accessed": "2022-08-30",
+  "date_accessed": "2022-09-09",
   "source_data_url": "https://unstats.un.org/sdgapi/swagger/",
   "license_url": "http://creativecommons.org/licenses/by/3.0/igo/",
   "license_name": "CC BY 3.0 IGO",
@@ -15,5 +15,5 @@
   "publication_year": 2022,
   "publication_date": "2022-07-11",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/un/2022-07-11/un_wpp.zip",
-  "md5": "da6c7089d9fc7ed26e38e1468aa58903"
+  "md5": "e49634a6a64f5b290d2f3a56837b44a1"
 }


### PR DESCRIPTION
Added `variant=constant fertility` for metric `population`. The motivation for this was [this chart](https://ourworldindata.org/grapher/comparison-of-world-population-projections).


![sex-ratio-at-birth-vs-five-years-old](https://user-images.githubusercontent.com/18101289/189353378-edd83c9d-4af6-4ec6-8982-b3f686ce5c7e.png)


---

xref https://github.com/owid/owid-issues/issues/412
