### PR TITLE
fix(catalog): replace file in ensure_downloaded() if checksum does not match

### DIFF
--- a/owid/walden/catalog.py
+++ b/owid/walden/catalog.py
@@ -181,22 +181,11 @@ class Dataset:
     def relative_base(self):
         return path.join(self.namespace, self.version, f"{self.short_name}")
 
-    def _download(self, filename: str, quiet: bool) -> None:
-        # actually get it
-        url = self.owid_data_url or self.source_data_url
-        if not url:
-            raise Exception(f"dataset {self.name} has neither source_data_url nor owid_data_url")
-        if self.is_public:
-            files.download(url, filename, expected_md5=self.md5, quiet=quiet)
-        else:
-            owid_cache.download(url, filename, expected_md5=self.md5, quiet=quiet)
-
     def ensure_downloaded(self, quiet=False) -> str:
-        "Download it if it hasn't already been downloaded. Return the local file path."
+        "Download it if it hasn't already been downloaded and matches checksum. Return the local file path."
         filename = self.local_path
 
         if self.md5 and path.exists(filename) and files.checksum(filename) == self.md5:
-            # if path.exists(filename):
             return filename
         else:
             # make the parent folder

--- a/owid/walden/files.py
+++ b/owid/walden/files.py
@@ -87,7 +87,8 @@ def download(url: str, filename: str, expected_md5: Optional[str] = None, quiet:
             if os.path.exists(filename):
                 os.remove(filename)
             raise ChecksumDoesNotMatch(
-                f"for file downloaded from {url}:\n\twalden index checksum = {expected_md5}\n\tdownloaded checksum = {md5}"
+                f"for file downloaded from {url}. Is your walden repository up to date?\n\twalden index checksum = {expected_md5}\n\tdownloaded checksum = {md5}"
+                ""
             )
 
     shutil.move(tmp_filename, filename)


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/552

## Problem

When someone reuploads a dataset in walden, existing cache in `~/.owid/walden` won't get invalidated and we'll assume we have a correct file even though it has a different checksum. This could be troublesome especially for backported datasets.

## Solution chosen

In calls to `ensure_downloaded()`, check the checksum against the walden record and re-download the file if there's a checksum mismatch.

## Alternative option (not chosen)

Save files in cache as `~/.owid/walden/.../short_name.[md5].[ext]`. If md5 gets updated in walden index, it'll force us to download a new file. This is much faster than checking dirtiness at runtime in `WaldenStep`.

After we merge this, everyone could remove their `~/.owid` folder to free up some space. This will also trigger a completely new rebuild of ETL.

We leave it up to user to clean up their cache. Perhaps we could do the cleaning as part of `make prune` command in ETL. (Or even better, after merging ETL and walden we could move `~/.owid` to `/etl/data`)