### PR TITLE
chore: audit that we always keep a copy of the data

### DIFF
--- a/owid/walden/audit.py
+++ b/owid/walden/audit.py
@@ -39,15 +39,12 @@ def audit_doc(filename: str, document: dict, schema: dict) -> None:
     print(Path(filename).relative_to(catalog.INDEX_DIR))
     jsonschema.validate(document, schema)
 
-    if "owid_data_url" in document:
-        check_url(document["owid_data_url"])
-        if "source_data_url" in document:
-            check_url(document["source_data_url"], strict=False)
-    else:
-        if "source_data_url" not in document:
-            raise Exception(f"No source_data_url or owid_data_url in: {filename}")
+    if "owid_data_url" not in document:
+        raise Exception(f"Missing 'owid_data_url' in {filename}")
 
-        check_url(document["source_data_url"])
+    check_url(document["owid_data_url"])
+    if "source_data_url" in document:
+        check_url(document["source_data_url"], strict=False)
 
 
 def check_url(url: str, strict: bool = True) -> None:


### PR DESCRIPTION
Check that we always have `owid_data_url`, meaning that we in fact always cache a copy of the remote data.

This is important because 6m or 1y later the data provider often stops hosting the original data in the same place. At that time, we will really want to have kept a copy so that we can rebuild the dataset.
