### PR TITLE
data(life-exp): add data from riley2005

### DIFF
--- a/ingests/papers/2022-11-01/riley2005/__main__.py
+++ b/ingests/papers/2022-11-01/riley2005/__main__.py
@@ -1,0 +1,84 @@
+"""Walden step for WB Gender statistics dataset.
+
+WB maintains the dataset in a stable URL, where new releases overwrite past releases.
+
+To understand for which walden datasets this code has been used note the following:
+- For each Walden dataset version there is one corresponding Walden code version.
+- For each Walden code version there can be >1 Walden dataset versions.
+
+That is, this code may have generated several walden datasets versions.
+
+To find which code generated your dataset version "YYYY-MM-DD", look for the code version closes in time with that version
+backwards.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import click
+from structlog import get_logger
+
+from owid.walden import Catalog, Dataset
+
+log = get_logger()
+
+
+METADATA_FILENAME = Path(__file__).parent / "meta.yml"
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Walden",
+)
+def main(upload: bool) -> None:
+    metadata = Dataset.from_yaml(METADATA_FILENAME)
+
+    # download dataset from source_data_url and add the local file to Walden's cache in ~/.owid/walden
+    dataset = Dataset.download_and_create(metadata)
+
+    if needs_to_be_updated(dataset):
+        log.info("Update needed! Updating dataset...")
+        # Update version, publication year
+        dataset.version = dataset.date_accessed
+
+        # upload it to S3
+        if upload:
+            dataset.upload(public=True)
+
+        # update PUBLIC walden index with metadata
+        dataset.save()
+    else:
+        log.info("No update needed!")
+
+
+def needs_to_be_updated(dataset: Dataset) -> bool:
+    """Check if dataset needs to be updated.
+
+    Retrieves last version of the dataset in Walden and compares it to the current version. Comparison is done by
+    string comparing the MD5 checksums of the two datasets.
+
+    TODO: move to class method of Dataset.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        Dataset that was just retrieved.
+
+    Returns
+    -------
+    bool
+        True if dataset in Walden is outdated and a new version is needed.
+    """
+    log.info("Checking if dataset needs to be updated...")
+    try:
+        dataset_last = Catalog().find_latest(namespace=dataset.namespace, short_name=dataset.short_name)
+        return dataset_last.md5 != dataset.md5
+    except ValueError:
+        return True
+
+
+if __name__ == "__main__":
+    main()

--- a/ingests/papers/2022-11-01/riley2005/meta.yml
+++ b/ingests/papers/2022-11-01/riley2005/meta.yml
@@ -1,0 +1,17 @@
+namespace: papers
+short_name: papers_riley2005
+name: Estimates of Regional and Global Life Expectancy, 1800-2001 - Riley (2005)
+source_name: Riley (2005)
+version: overwritten_in_code
+url: https://doi.org/10.1111/j.1728-4457.2005.00083.x
+source_data_url: https://u.demog.berkeley.edu/~jrw/Biblio/Eprints/%20P-S/riley.2005_estimates.global.e0.pdf
+file_extension: pdf
+license_url: https://about.jstor.org/terms/
+license_name: JSTOR
+publication_year: 2005
+publication_date: 2005-10-21
+description: |
+  Historians and demographers have gone to considerable trouble to reconstruct life expectancy in the past in individual countries.
+  This overview collects information from a large body of that work and links estimates for historical populations to those provided by 
+  the United Nations, the World Bank, and other sources for 1950–2001. The result is a picture of regional and global life expectancy 
+  at birth for selected years from 1800 to 2001. The bibliography of more than 700 sources is published separately on the web.

--- a/owid/walden/index/papers/2022-11-01/papers_riley2005.json
+++ b/owid/walden/index/papers/2022-11-01/papers_riley2005.json
@@ -1,0 +1,19 @@
+{
+  "namespace": "papers",
+  "short_name": "papers_riley2005",
+  "name": "Estimates of Regional and Global Life Expectancy, 1800-2001 - Riley (2005)",
+  "description": "Historians and demographers have gone to considerable trouble to reconstruct life expectancy in the past in individual countries.\nThis overview collects information from a large body of that work and links estimates for historical populations to those provided by \nthe United Nations, the World Bank, and other sources for 1950\u20132001. The result is a picture of regional and global life expectancy \nat birth for selected years from 1800 to 2001. The bibliography of more than 700 sources is published separately on the web.\n",
+  "source_name": "Riley (2005)",
+  "url": "https://doi.org/10.1111/j.1728-4457.2005.00083.x",
+  "file_extension": "pdf",
+  "date_accessed": "2022-11-01",
+  "source_data_url": "https://u.demog.berkeley.edu/~jrw/Biblio/Eprints/%20P-S/riley.2005_estimates.global.e0.pdf",
+  "license_url": "https://about.jstor.org/terms/",
+  "license_name": "JSTOR",
+  "is_public": true,
+  "version": "2022-11-01",
+  "publication_year": 2005,
+  "publication_date": "2005-10-21",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/papers/2022-11-01/papers_riley2005.pdf",
+  "md5": "9b1bbf6223420a4cda36edacbeefc6a5"
+}


### PR DESCRIPTION
- Add life expectancy at 0 years old from [Estimates of Regional and Global Life Expectancy, 1800-2001 - Riley (2005)](https://u.demog.berkeley.edu/~jrw/Biblio/Eprints/%20P-S/riley.2005_estimates.global.e0.pdf)
- I created a new namespace, `papers`, where we can add the ingest scripts for data coming from specific papers/journals. Same approach as in #117.

This script ingests a PDF. My idea is to parse it somehow later in Meadow. Data is contained in a single small table (see table 1 in link above), so perhaps it is doable. 